### PR TITLE
update ghost locations for new badge tech

### DIFF
--- a/locations/overworld.json
+++ b/locations/overworld.json
@@ -341,7 +341,7 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 370,
+                "x": 352,
                 "y": 840,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
@@ -456,7 +456,7 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 225,
+                "x": 253,
                 "y": 840,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
@@ -1487,8 +1487,8 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1770,
-                "y": 1525,
+                "x": 1790,
+                "y": 1545,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
             }
@@ -1511,7 +1511,7 @@
             {
                 "map": "lightworld",
                 "x": 1835,
-                "y": 1525,
+                "y": 1545,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
             }
@@ -1562,7 +1562,7 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1770,
+                "x": 1810,
                 "y": 1590,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
@@ -3913,8 +3913,8 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1770,
-                "y": 1525,
+                "x": 1790,
+                "y": 1545,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
             }
@@ -3963,7 +3963,7 @@
             {
                 "map": "darkworld",
                 "x": 1835,
-                "y": 1525,
+                "y": 1545,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]
             }
@@ -4014,7 +4014,7 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1770,
+                "x": 1810,
                 "y": 1590,
                 "size": 48,
                 "restrict_visibility_rules": [ "entrance_shuffle_on" ]

--- a/locations/overworldghost.json
+++ b/locations/overworldghost.json
@@ -1,6 +1,24 @@
 [
     // Light World
     {
+        "name": "Master Sword Pedestal Ghost",
+        "sections": [
+            {
+                "name": "Pedestal",
+                "item_count": 1
+            }
+        ],
+        "map_locations": [
+            {
+                "map": "lightworld",
+                "x": 83,
+                "y": 118,
+                "size": 0,
+                "badge_size": 90
+            }
+        ]
+    },
+    {
         "name": "Forest Chest Game Ghost",
         "sections": [
             {
@@ -11,9 +29,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 332,
-                "y": 48,
-                "size": 0
+                "x": 370,
+                "y": 56,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -28,9 +47,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 344,
-                "y": 263,
-                "size": 0
+                "x": 382,
+                "y": 271,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -45,9 +65,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 332,
-                "y": 313,
-                "size": 0
+                "x": 370,
+                "y": 321,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -62,9 +83,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 562,
-                "y": 153,
-                "size": 0
+                "x": 600,
+                "y": 169,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -79,9 +101,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 625,
-                "y": 68,
-                "size": 0
+                "x": 663,
+                "y": 84,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -96,9 +119,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 633,
-                "y": 128,
-                "size": 0
+                "x": 671,
+                "y": 144,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -113,9 +137,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 337,
-                "y": 643,
-                "size": 0
+                "x": 375,
+                "y": 659,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -130,9 +155,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 257,
-                "y": 853,
-                "size": 0
+                "x": 295,
+                "y": 860,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -147,9 +173,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 332,
-                "y": 853,
-                "size": 0
+                "x": 352,
+                "y": 863,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -164,9 +191,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 62,
-                "y": 953,
-                "size": 0
+                "x": 100,
+                "y": 963,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -181,9 +209,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 377,
-                "y": 973,
-                "size": 0
+                "x": 415,
+                "y": 983,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -198,9 +227,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 187,
-                "y": 848,
-                "size": 0
+                "x": 253,
+                "y": 858,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -215,9 +245,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 8,
-                "y": 841,
-                "size": 0
+                "x": 46,
+                "y": 851,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -232,9 +263,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 57,
-                "y": 865,
-                "size": 0
+                "x": 95,
+                "y": 875,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -249,9 +281,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 164,
-                "y": 1084,
-                "size": 0
+                "x": 202,
+                "y": 1094,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -266,9 +299,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 372,
-                "y": 1078,
-                "size": 0
+                "x": 410,
+                "y": 1088,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -283,9 +317,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 282,
-                "y": 1203,
-                "size": 0
+                "x": 320,
+                "y": 1213,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -300,9 +335,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 182,
-                "y": 1183,
-                "size": 0
+                "x": 220,
+                "y": 1193,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -317,9 +353,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 17,
-                "y": 1203,
-                "size": 0
+                "x": 55,
+                "y": 1213,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -334,9 +371,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 272,
-                "y": 1080,
-                "size": 0
+                "x": 310,
+                "y": 1090,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -351,9 +389,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 577,
-                "y": 1060,
-                "size": 0
+                "x": 615,
+                "y": 1070,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -368,9 +407,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 612,
-                "y": 1158,
-                "size": 0
+                "x": 650,
+                "y": 1168,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -385,9 +425,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 597,
-                "y": 1114,
-                "size": 0
+                "x": 635,
+                "y": 1124,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -402,9 +443,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 394,
-                "y": 1408,
-                "size": 0
+                "x": 432,
+                "y": 1418,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -419,9 +461,10 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 182,
-                "y": 1443,
-                "size": 0
+                "x": 220,
+                "y": 1453,
+                "size": 0,
+                "badge_size": 90
             }
         ]
     },
@@ -436,9 +479,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 242,
-                "y": 1443,
-                "size": 0
+                "x": 280,
+                "y": 1453,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -453,9 +498,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 42,
-                "y": 1402,
-                "size": 0
+                "x": 100,
+                "y": 1412,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -470,9 +517,30 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 275,
+                "x": 313,
+                "y": 1338,
+                "size": 0,
+                "badge_size": 90
+
+            }
+        ]
+    },
+    {
+        "name": "Library Ghost",
+        "map_locations": [
+            {
+                "map": "lightworld",
+                "x": 313,
                 "y": 1328,
-                "size": 0
+                "size":0,
+                "badge_size": 90
+
+            }
+        ],
+        "sections": [
+            {
+                "name": "On The Shelf",
+                "item_count": 1
             }
         ]
     },
@@ -489,7 +557,9 @@
                 "map": "lightworld",
                 "x": 1196,
                 "y": 834,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -504,9 +574,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1067,
-                "y": 866,
-                "size": 0
+                "x": 1105,
+                "y": 876,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -521,9 +593,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 965,
-                "y": 894,
-                "size": 0
+                "x": 1003,
+                "y": 904,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -538,9 +612,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1060,
-                "y": 1374,
-                "size": 0
+                "x": 1098,
+                "y": 1402,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -555,9 +631,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1162,
+                "x": 1200,
                 "y": 1573,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -572,9 +650,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1262,
+                "x": 1300,
                 "y": 1623,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -589,9 +669,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1422,
+                "x": 1460,
                 "y": 1548,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -606,9 +688,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 897,
+                "x": 945,
                 "y": 1318,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -623,9 +707,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 494,
+                "x": 532,
                 "y": 1671,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -640,9 +726,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 904,
+                "x": 942,
                 "y": 1888,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -657,9 +745,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1271,
+                "x": 1309,
                 "y": 1895,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -674,9 +764,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1732,
-                "y": 1533,
-                "size": 0
+                "x": 1790,
+                "y": 1553,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -691,9 +783,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1797,
-                "y": 1533,
-                "size": 0
+                "x": 1835,
+                "y": 1553,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -708,9 +802,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1732,
+                "x": 1810,
                 "y": 1598,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -725,9 +821,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1569,
+                "x": 1607,
                 "y": 678,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -742,9 +840,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1587,
+                "x": 1625,
                 "y": 908,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -759,9 +859,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1612,
+                "x": 1650,
                 "y": 1303,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -776,9 +878,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1932,
+                "x": 1970,
                 "y": 1413,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -793,9 +897,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1886,
+                "x": 1924,
                 "y": 838,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -810,9 +916,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1252,
+                "x": 1290,
                 "y": 633,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -827,9 +935,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1303,
+                "x": 1341,
                 "y": 566,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -844,9 +954,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1002,
+                "x": 1040,
                 "y": 598,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -861,9 +973,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 884,
+                "x": 922,
                 "y": 548,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -878,9 +992,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 739,
+                "x": 777,
                 "y": 608,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -895,9 +1011,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1169,
+                "x": 1207,
                 "y": 606,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -912,9 +1030,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1094,
+                "x": 1132,
                 "y": 557,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -931,9 +1051,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 862,
+                "x": 900,
                 "y": 788,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -948,9 +1070,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1067,
+                "x": 1105,
                 "y": 788,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -965,9 +1089,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 965,
+                "x": 1003,
                 "y": 802,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -982,9 +1108,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 965,
+                "x": 1003,
                 "y": 848,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -999,9 +1127,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 863,
+                "x": 901,
                 "y": 866,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1018,9 +1148,30 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1768,
+                "x": 1806,
                 "y": 294,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
+            }
+        ]
+    },
+    {
+        "name": "Zora's Domain Ghost",
+        "sections": [
+            {
+                "name": "Ledge",
+                "item_count": 1
+            }
+        ],
+        "map_locations": [
+            {
+                "map": "lightworld",
+                "x": 1920,
+                "y": 281,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1035,15 +1186,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1412,
+                "x": 1450,
                 "y": 1674,
-                "size": 0
-            },
-            {
-                "map": "darkworld",
-                "x": 1412,
-                "y": 1674,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1058,9 +1205,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1557,
+                "x": 1595,
                 "y": 1718,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1076,9 +1225,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 32,
+                "x": 70,
                 "y": 1598,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1093,9 +1244,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 110,
+                "x": 148,
                 "y": 1548,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1111,8 +1264,10 @@
             {
                 "map": "lightworld",
                 "x": 40,
-                "y": 1835,
-                "size": 0
+                "y": 1843,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1127,9 +1282,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 187,
+                "x": 225,
                 "y": 1598,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1144,9 +1301,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 110,
+                "x": 148,
                 "y": 1608,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1161,9 +1320,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 362,
+                "x": 400,
                 "y": 1663,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1178,9 +1339,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 517,
+                "x": 555,
                 "y": 1798,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1195,9 +1358,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 587,
+                "x": 625,
                 "y": 1928,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1212,9 +1377,30 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 316,
+                "x": 354,
                 "y": 1568,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
+            }
+        ]
+    },
+    {
+        "name": "Bombos Tablet Ghost",
+        "sections": [
+            {
+                "name": "Tablet",
+                "item_count": 1
+            }
+        ],
+        "map_locations": [
+            {
+                "map": "lightworld",
+                "x": 452,
+                "y": 1853,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1229,9 +1415,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 679,
+                "x": 715,
                 "y": 366,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1246,9 +1434,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 690,
+                "x": 720,
                 "y": 313,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1264,9 +1454,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 42,
+                "x": 80,
                 "y": 118,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1281,9 +1473,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 80,
+                "x": 118,
                 "y": 262,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1298,9 +1492,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 206,
+                "x": 244,
                 "y": 182,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1315,9 +1511,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 312,
+                "x": 350,
                 "y": 283,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1332,9 +1530,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 331,
+                "x": 369,
                 "y": 305,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1349,9 +1549,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 252,
+                "x": 290,
                 "y": 293,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1366,9 +1568,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 354,
+                "x": 392,
                 "y": 353,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1383,9 +1587,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 276,
+                "x": 314,
                 "y": 362,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1400,7 +1606,7 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 342,
+                "x": 380,
                 "y": 257,
                 "size": 0
                 
@@ -1418,9 +1624,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 637,
+                "x": 675,
                 "y": 123,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1435,9 +1643,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 886,
+                "x": 924,
                 "y": 559,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1452,9 +1662,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 627,
+                "x": 665,
                 "y": 920,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1469,9 +1681,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 339,
+                "x": 377,
                 "y": 643,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1486,9 +1700,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 62,
+                "x": 100,
                 "y": 944,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1503,9 +1719,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 217,
+                "x": 255,
                 "y": 983,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1520,9 +1738,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 376,
+                "x": 414,
                 "y": 977,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1537,9 +1757,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 181,
+                "x": 219,
                 "y": 1179,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1554,9 +1776,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 332,
+                "x": 408,
                 "y": 1076,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1571,9 +1795,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 370,
+                "x": 408,
                 "y": 1077,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1588,9 +1814,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1578,
+                "x": 1616,
                 "y": 677,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1605,9 +1833,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 393,
+                "x": 431,
                 "y": 1408,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1622,9 +1852,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 907,
+                "x": 945,
                 "y": 1318,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1639,9 +1871,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1060,
+                "x": 1098,
                 "y": 1340,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1656,9 +1890,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1162,
+                "x": 1200,
                 "y": 1568,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1673,9 +1909,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 902,
+                "x": 940,
                 "y": 1885,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1690,9 +1928,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1262,
+                "x": 1300,
                 "y": 1623,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1707,9 +1947,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 962,
+                "x": 1000,
                 "y": 823,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1724,9 +1966,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 836,
+                "x": 874,
                 "y": 984,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1741,7 +1985,7 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 902,
+                "x": 940,
                 "y": 984,
                 "size": 0
             }
@@ -1758,9 +2002,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1618,
+                "x": 1656,
                 "y": 1304,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1775,9 +2021,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1668,
+                "x": 1706,
                 "y": 1016,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1792,9 +2040,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1886,
+                "x": 1924,
                 "y": 838,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1809,9 +2059,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1930,
+                "x": 1968,
                 "y": 1413,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1826,9 +2078,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1732,
+                "x": 1790,
                 "y": 1533,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1843,9 +2097,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1797,
+                "x": 1835,
                 "y": 1533,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1860,9 +2116,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1732,
+                "x": 1810,
                 "y": 1598,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1877,9 +2135,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 598,
+                "x": 636,
                 "y": 1222,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1894,9 +2154,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 682,
+                "x": 728,
                 "y": 313,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1911,9 +2173,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 677,
+                "x": 717,
                 "y": 365,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1928,9 +2192,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 637,
+                "x": 669,
                 "y": 323,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1945,9 +2211,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1562,
+                "x": 1600,
                 "y": 1745,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1963,9 +2231,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 110,
+                "x": 148,
                 "y": 1618,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1980,9 +2250,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 39,
+                "x": 77,
                 "y": 1608,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -1997,9 +2269,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 182,
+                "x": 220,
                 "y": 1608,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2014,14 +2288,35 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 362,
+                "x": 400,
                 "y": 1663,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
 
     // Death Mountain
+    {
+        "name": "Ether Tablet Ghost",
+        "sections": [
+            {
+                "name": "Tablet",
+                "item_count": 1
+            }
+        ],
+        "map_locations": [
+            {
+                "map": "lightworld",
+                "x": 844,
+                "y": 46,
+                "size": 0,
+                "badge_size": 90
+
+            }
+        ]
+    },
     {
         "name": "Tower of Hera Entrance Ghost",
         "sections": [
@@ -2033,9 +2328,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1087,
+                "x": 1125,
                 "y": 84,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2050,9 +2347,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1687,
+                "x": 1725,
                 "y": 133,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2067,9 +2366,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1589,
+                "x": 1627,
                 "y": 48,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2084,9 +2385,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 778,
+                "x": 816,
                 "y": 386,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2101,9 +2404,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 862,
+                "x": 900,
                 "y": 458,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2118,9 +2423,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1037,
+                "x": 1075,
                 "y": 333,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2135,9 +2442,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 752,
+                "x": 790,
                 "y": 283,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2152,9 +2461,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 882,
+                "x": 920,
                 "y": 288,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2169,9 +2480,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 942,
+                "x": 980,
                 "y": 298,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2186,9 +2499,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 937,
+                "x": 975,
                 "y": 213,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2203,9 +2518,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1559,
+                "x": 1597,
                 "y": 268,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2220,9 +2537,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1652,
+                "x": 1690,
                 "y": 298,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2237,9 +2556,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1697,
+                "x": 1735,
                 "y": 298,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2254,9 +2575,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1697,
+                "x": 1735,
                 "y": 298,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2271,9 +2594,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1693,
+                "x": 1731,
                 "y": 442,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2288,9 +2613,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1607,
+                "x": 1645,
                 "y": 238,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2305,9 +2632,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1562,
+                "x": 1600,
                 "y": 188,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2322,9 +2651,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1657,
+                "x": 1695,
                 "y": 188,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2339,9 +2670,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1607,
+                "x": 1645,
                 "y": 283,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2356,9 +2689,11 @@
         "map_locations": [
             {
                 "map": "lightworld",
-                "x": 1982,
+                "x": 1020,
                 "y": 178,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2374,9 +2709,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1589,
+                "x": 1627,
                 "y": 48,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2391,9 +2728,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1087,
+                "x": 1125,
                 "y": 84,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2408,9 +2747,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1632,
+                "x": 1670,
                 "y": 134,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2425,9 +2766,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1687,
+                "x": 1725,
                 "y": 123,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2442,9 +2785,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1852,
+                "x": 1890,
                 "y": 173,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2459,9 +2804,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1113,
+                "x": 1151,
                 "y": 302,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2477,8 +2824,10 @@
             {
                 "map": "darkworld",
                 "x": 815,
-                "y": 376,
-                "size": 0
+                "y": 384,
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2493,9 +2842,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1560,
+                "x": 1598,
                 "y": 190,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2510,9 +2861,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1656,
+                "x": 1694,
                 "y": 190,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2527,9 +2880,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1610,
+                "x": 1648,
                 "y": 238,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2544,9 +2899,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1642,
+                "x": 1680,
                 "y": 295,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     },
@@ -2562,9 +2919,11 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 1696,
+                "x": 1728,
                 "y": 303,
-                "size": 0
+                "size": 0,
+                "badge_size": 90
+
             }
         ]
     }

--- a/scripts/capturebadgeer.lua
+++ b/scripts/capturebadgeer.lua
@@ -210,7 +210,7 @@ CaptureBadgeItems = {
     "@Desert Ledge/Ledge",
     "@Floating Island/Island",
     "@Lake Hylia Island/Island",
-    "@Spectacle Rock/Up On Top",
+    "@Spec Rock/Up On Top",
     "@Bumper Ledge/Ledge",
     "@Zora's Domain/Ledge",
     "@Library/On The Shelf",


### PR DESCRIPTION
Add badge size to all ghost locations
adj XY coords to place badges centered on locations
move all locations that were moved
to acomidate off center badges.
fix non functioning item locations

some Y Coords will need to be adjusted once the images are standardized