### PR TITLE
Fix a couple of Badge Coords and lumberjack house badge not shown

### DIFF
--- a/locations/ghosts.json
+++ b/locations/ghosts.json
@@ -1058,7 +1058,7 @@
             {
                 "map": "lightworld",
                 "x": 1003,
-                "y": 766,
+                "y": 776,
                 "size": 0,
                 "badge_size": 96
             }
@@ -2054,8 +2054,8 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 728,
-                "y": 313,
+                "x": 733,
+                "y": 290,
                 "size": 0,
                 "badge_size": 96
             }
@@ -2072,8 +2072,8 @@
         "map_locations": [
             {
                 "map": "darkworld",
-                "x": 717,
-                "y": 365,
+                "x": 727,
+                "y": 368,
                 "size": 0,
                 "badge_size": 96
             }

--- a/scripts/global.lua
+++ b/scripts/global.lua
@@ -3,7 +3,7 @@ TRACKER_READY = false
 
 CaptureBadgeEntrances = {
     "@Lumberjack Tree Dropdown/Dropdown",
-    "@Lumberjack Tree Entrance/Entrance",
+    "@Lumberjack House/Entrance",
     "@Death Mountain Entry Cave/Entrance",
     "@Death Mountain Exit Back/Entrance",
     "@Kakariko Fortune Teller/Entrance",
@@ -133,7 +133,7 @@ CaptureBadgeEntrances = {
 CaptureBadgeInsanity = {
     "@Castle Secret Entrance/Entrance",
     "@Sanctuary Entrance/Entrance",
-    "@Lumberjack House/Entrance",
+    "@Lumberjack Tree Entrance/Entrance",
     "@Forest Hideout Entrance/Entrance",
     "@Kakariko Well Entrance/Entrance",
     "@Magic Bat Entrance/Entrance",


### PR DESCRIPTION
Fix Aga tower entrance badge to work better with the moving entrance.
Fix Bumper Cave Badge Coords from prievous conflict.
fix lumberjack house badge. location swap in global.lua