### PR TITLE
fix sendExternalMessage file path

### DIFF
--- a/scripts/fileio.lua
+++ b/scripts/fileio.lua
@@ -54,7 +54,9 @@ function sendExternalMessage(filename, value)
                 or (filename == "health" and not CONFIG.AUTOTRACKER_ENABLE_EXTERNAL_HEALTH_FILE) then
             return
         end
-        local file = io.open(os.getenv("USERPROFILE") .. "\\Documents\\EmoTracker\\" .. filename .. ".txt", "w+")
+        
+        local fullDir, packRoot = getFullDir()
+        local file = io.open(fullDir .. filename .. ".txt", "w+")
         if file then
             io.output(file)
             io.write(value)


### PR DESCRIPTION
- uses getFullDir() when determining the external file location

I was going crazy trying to figure out why, after signing up for OneDrive, I couldn't for the life of me find my `item.txt` file in my "Documents" folder.

Seems Microsoft, in their infinite wisdom, when they started syncing my home directory to the cloud, put it on this subtly different path.  And the code accommodates this for user override settings, but assumes the "traditional" path for the item/dungeon/health files.  